### PR TITLE
Tidyselect distvalues

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -3,29 +3,3 @@ is.date <- function(x) {
   inherits(x, c("Date", "POSIXt"))
 }
 
-last_verb <- function() {
-
-  # get trace_back info
-  trace_bck <- rlang::trace_back()
-
-  # get call names
-  call_fns <- lapply(trace_bck$calls, function(x) { `[[`(x, 1) })
-
-  # get last dplyr verb
-  out <- max(which(grepl("^dplyr:::[mutate|summarise|summarize|filter|select|arrange|transmute]", call_fns)))
-
-  out
-}
-
-# this function is copied from dplyr
-# see README section Acknowledgements as well as dplyr's license and copyright
-data_mask_top <- function(env, recursive = FALSE, inherit = FALSE) {
-  while (rlang::env_has(env, ".__tidyeval_data_mask__.", inherit = inherit)) {
-    env <- rlang::env_parent(rlang::env_get(env, ".top_env", inherit = inherit))
-    if (!recursive) {
-      return(env)
-    }
-  }
-
-  env
-}

--- a/R/convenience_funs.R
+++ b/R/convenience_funs.R
@@ -1,0 +1,39 @@
+#' Compare a vector against a value for equality of values
+#'
+#' @description
+#' ...
+#'
+#' @param check An atomic vector.
+#' @param against A value of length one against the values in `check` are compared.
+#'
+#' @return
+#'
+#' @section Examples:
+#'
+#' ```{r, child = "man/rmd/setup.Rmd"}
+#' ```
+#'
+#' Show all special cases:
+#' check is factor with NA
+#' against is named
+#' 1 == 1L
+#'
+#' @export
+same_value <- function(check, against) {
+
+  if (length(against) > 1) {
+    rlang::abort(c("Problem with `same_value()` input `against`.",
+                   i = "Only vectors of length 1 allowed in `against`.",
+                   x = glue::glue("Length of y is {length(against)}.")))
+  }
+
+  if (is.na(against)) {
+
+    return(is.na(check))
+
+  } else {
+
+    return(ifelse(is.na(check), FALSE, check == against))
+
+  }
+}

--- a/R/deprec-dist_values.R
+++ b/R/deprec-dist_values.R
@@ -1,0 +1,148 @@
+#' Select distinct values of a variable
+#'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#' This functions was a [selection helpers][selection_helpers] and is replaced by
+#' [unique_tidy()]. Apart from having a more meaningful name, `unique_tidy` supports
+#' tidyselection
+#'
+#' `dist_values` was intended to be used inside all functions that accept a vector
+#' as argument (that is `over()` and `crossover()` and all their variants) to extract
+#' values of a variable. [dist_values()] returns all distinct values (or in the case of
+#' factor variables: levels) of a variable `x` which are not `NA`.
+#'
+#' @param x An atomic vector or list. For [seq_range()] x must be numeric or date.
+#' @param sep  A character vector containing regular expression(s) which are used
+#'   for splitting the values (works only if x is a character vector).
+#' @param sort A character string indicating which sorting scheme is to be applied
+#'   to distinct values: ascending ("asc"), descending ("desc"), "none" or "levels". The
+#'   default is ascending, only if x is a factor the default is "levels".
+#'
+#' @return
+#' [dist_values()] returns a vector of the same type of x, with exception of
+#' factors which are converted to type `"character"`.
+#'
+#' @section Examples:
+#' TODO: Show how old examples can be expressed with `unique_tidy`
+#' ```{r, child = "man/rmd/setup.Rmd"}
+#' ```
+#'
+#' Selection helpers can be used inside `dplyover::over()` which in turn must be
+#' used inside `dplyr::mutate` or `dplyr::summarise`. Let's first attach `dplyr`:
+#'
+#' ```{r, comment = "#>", collapse = TRUE}
+#' library(dplyr)
+#'
+#' # For better printing
+#' iris <- as_tibble(iris)
+#' ```
+#'
+#' `dist_values()` extracts all distinct values of a column variable.
+#' This is helpful when creating dummy variables in a loop using `over()`.
+#'
+#' ```{r, comment = "#>", collapse = TRUE}
+#' iris %>%
+#'   mutate(over(dist_values(Species),
+#'               ~ if_else(Species == .x, 1, 0)
+#'               ),
+#'          .keep = "none")
+#' ```
+#'
+#' `dist_values()` is just a wrapper around unique. However, it has five
+#' differences:
+#'
+#' (1) `NA` values are automatically stripped. Compare:
+#'
+#' ```{r, comment = "#>", collapse = TRUE}
+#' unique(c(1:3, NA))
+#' dist_values(c(1:3, NA))
+#' ```
+#'
+#' (2) Applied on factors, `dist_values()` returns all distinct `levels` as
+#' character. Compare the following:
+#'
+#' ```{r, comment = "#>", collapse = TRUE}
+#' fctrs <- factor(c(1:3, NA), levels = c(3:1))
+#'
+#' fctrs %>% unique() %>% class()
+#'
+#' fctrs %>% dist_values() %>% class()
+#' ```
+#'
+#' (3) As default, the output is sorted in ascending order for non-factors, and
+#' is sorted as the underyling "levels" for factors. This can be controlled by
+#' setting the `sort` argument. Compare:
+#'
+#' ```{r, comment = "#>", collapse = TRUE}
+#' # non-factors
+#' unique(c(3,1,2))
+#'
+#' dist_values(c(3,1,2))
+#' dist_values(c(3,1,2), sort = "desc")
+#' dist_values(c(3,1,2), sort = "none")
+#'
+#' # factors
+#' fctrs <- factor(c(2,1,3, NA), levels = c(3:1))
+#'
+#' dist_values(fctrs)
+#' dist_values(fctrs, sort = "levels")
+#' dist_values(fctrs, sort = "asc")
+#' dist_values(fctrs, sort = "desc")
+#' dist_values(fctrs, sort = "none")
+#'
+#' ```
+#'
+#' (4) When used on a character vector `dist_values` can take a separator
+#' `sep` to split the elements accordingly:
+#'
+#' ```{r, comment = "#>", collapse = TRUE}
+#' c("1, 2, 3",
+#'   "2, 4, 5",
+#'   "4, 1, 7") %>%
+#'   dist_values(., sep = ", ")
+#' ```
+#'
+#' (5) When used on lists `dist_values` automatically simplifiies its input
+#' into a vector using `unlist`:
+#'
+#' ```{r, comment = "#>", collapse = TRUE}
+#' list(a = c(1:4), b = (4:6), c(5:10)) %>%
+#'   dist_values()
+#' ```
+#' @keywords internal
+#' @export
+dist_values <- function(x, .sep = NULL, .sort = c("asc", "desc", "none", "levels")) {
+  lifecycle::deprecate_warn("0.0.9", "dist_values()", "unique_tidy()")
+
+  is_null <- identical(.sort, c("asc", "desc", "none", "levels"))
+  sort <- match.arg(.sort)
+
+  if (is.list(x)) {
+    x <- unlist(x)
+  }
+  if (!is.null(.sep)) {
+    x <- unlist(strsplit(x, .sep))
+  }
+
+  res <- as.vector(na.omit(unique(x)))
+  if (!is.factor(x)) {
+    if (sort == "asc") {
+      return(sort(res))
+    } else if (sort == "desc") {
+      return(sort(res, decreasing = TRUE))
+    } else {
+      return(res)
+    }
+  } else {
+    x <- levels(x)
+    if (is_null || .sort == "levels") {
+      return(x)
+    } else if (sort == "asc") {
+      return(sort(x))
+    } else if (sort == "desc") {
+      return(sort(x, decreasing = TRUE))
+    } else {
+      res
+    }
+  }
+}

--- a/R/dplyr_helpers.R
+++ b/R/dplyr_helpers.R
@@ -1,0 +1,128 @@
+# helper functions which help dealing with dplyr internals ...
+# ... without relying on dplyr's internal context functions and data mask
+#
+
+last_verb <- function() {
+
+  # get trace_back info
+  trace_bck <- rlang::trace_back()
+
+  # get call names
+  call_fns <- lapply(trace_bck$calls, function(x) { `[[`(x, 1) })
+
+  # get last dplyr verb
+  out <- max(which(grepl("^dplyr:::[mutate|summarise|summarize|filter|select|arrange|transmute]", call_fns)))
+
+  call_nm <- rlang::call_name(trace_bck$calls[[out]])
+
+  # verify that trace_back() covers all calls
+  sc <- lapply(sys.calls(), function(x) `[[`(x, 1))
+
+  if(length(sc) > length(trace_bck$calls)) {
+    for (i in rev(seq_along(sc))) {
+      if (as.character(sc[[i]])[1] == call_nm) {
+        out <- i
+        break
+      }
+    }
+  }
+
+  names(out) <- gsub("_.*", "", call_nm)
+  out
+}
+
+get_init_data <- function(dplyr_frame_no) {
+
+  dat <- get(".data", envir = sys.frame(dplyr_frame_no))
+
+  # if (is.null(dat) || inherits(dat, "rlang_fake_data_pronoun")) {
+  #   dat <- dynGet(".data", ifnotfound = NULL)
+  # }
+
+  if (is.null(dat) || inherits(dat, "rlang_fake_data_pronoun")) {
+    rlang::abort(c("Problem with `get_init_data()`.",
+                   x = "Could not access underlying dplyr data.",
+                   i = "Please report your call and session info under:\nhttps://github.com/TimTeaFan/dplyover/issues/14"))
+  }
+
+  dat
+
+}
+
+rebuild_data <- function(dplyr_frame_no) {
+
+  mutate_env <- sys.frame(dplyr_frame_no)
+
+  if (mutate_env$i == 1L && length(mutate_env$new_columns) == 0) {
+    return(get_init_data(dplyr_frame_no))
+
+  } else if ((mutate_env$i) - 1L == length(mutate_env$new_columns)) {
+    # setup: get initial and new data
+    dat <- get_init_data(dplyr_frame_no)
+    new_dat <- mutate_env$new_columns
+
+    # differentiate between new and existing columns
+    new_cols <- setdiff(names(new_dat), names(dat))
+    replace_cols <- intersect(names(new_dat), names(dat))
+
+    # replace existing columns
+    dat[, replace_cols] <- new_dat[replace_cols]
+    # cbind new columns
+    dat <- cbind(dat, new_dat[new_cols])
+
+    return(dat)
+
+  } else {
+    rlang::abort(rlang::abort(c("Problem with `rebuild_data()`.",
+                                x = "Could not rebuild underlying dplyr data.",
+                                i = "Please report your call and session info under:\nhttps://github.com/TimTeaFan/dplyover/issues/15")))
+  }
+}
+
+get_full_data <- function(dplyr_frame_no) {
+
+  switch(names(dplyr_frame_no),
+         "transmute" = ,
+         "mutate" = rebuild_data(dplyr_frame_no),
+         get_init_data(dplyr_frame_no)
+         )
+}
+
+access_groups <- function(dplyr_frame_no) {
+
+  mutate_env <- sys.frame(dplyr_frame_no)
+
+  n_grps <- length(mutate_env$rows)
+
+  if(is.null(n_grps) || length(n_grps) == 0) {
+    n_grps <- dplyr::n_groups(get_init_data(dplyr_frame_no))
+  }
+
+  n_grps
+}
+
+get_n_groups <- function(dplyr_frame_no) {
+
+  switch(names(dplyr_frame_no),
+         "transmute" = ,
+         "mutate" = access_groups(dplyr_frame_no),
+         dplyr::n_groups(get_init_data(dplyr_frame_no))
+  )
+}
+
+# get_col <- function {
+#
+# }
+
+# this function is one of the few copied functions from dplyr
+# see README section Acknowledgements as well as dplyr's license and copyright
+data_mask_top <- function(env, recursive = FALSE, inherit = FALSE) {
+  while (rlang::env_has(env, ".__tidyeval_data_mask__.", inherit = inherit)) {
+    env <- rlang::env_parent(rlang::env_get(env, ".top_env", inherit = inherit))
+    if (!recursive) {
+      return(env)
+    }
+  }
+
+  env
+}

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -29,15 +29,15 @@ reference:
     `crossover()` as well as their variants). 1. Helpers which select string
     parts of the column names (of the underyling data): `cut_names()` removes a
     specified pattern; `extract_names()` extracts a specified pattern.
-    2. Helpers which select values of a variable: `dist_values()` returns all
-    distinct values; `seq_range()` returns the sequence between the range of a
+    2. Helpers which select values of a variable: `unique_tidy()` returns all
+    unique values; `seq_range()` returns the sequence between the range of a
     variable. 3. A helper function `.()` that takes a glue specifcation as input,
     and evaluates the final argument string as name in the caller environment.
     Apart from those selection heplers, `show_prefix()` and `show_suffix()`
     show the common pre- or suffix for each pair of variables of two sets of
     colums.
   contents:
-  - dist_values
+  - unique_tidy
   - cut_names
   - "."
   - show_affix

--- a/tests/testthat/test-select_values.R
+++ b/tests/testthat/test-select_values.R
@@ -3,10 +3,10 @@
 library(dplyr)
 
 ## examples
-test_that("use case: dist_values() in over()", {
+test_that("use case: unique_tidy() in over()", {
 
   over_dist_val <- iris %>%
-    mutate(over(dist_values(Species),
+    mutate(over(unique_tidy(Species),
                 ~ if_else(Species == .x, 1, 0)
     ),
     .keep = "none")
@@ -21,22 +21,153 @@ test_that("use case: dist_values() in over()", {
 
 })
 
-test_that("dist_values() short examples", {
+test_that("unique_tidy() supports tidyselect syntax", {
 
-  expect_equal(dist_values(c(1:3, NA)), c(1:3))
+  over_dist_val <- mtcars %>%
+    mutate(over(unique_tidy(vs:am),
+                ~ if_else(mpg == .x, 1, 0)
+    ),
+    .keep = "none")
 
-  expect_equal(dist_values(c(1:3, NA), .sort = "desc"), c(3:1))
+  df_expect <- mtcars %>%
+    mutate(`0` = 0,
+           `1` = 0,
+           .keep = "none")
 
-  expect_equal(dist_values(c(3, 1, 2, NA), .sort = "none"), c(3, 1, 2))
+  expect_equal(over_dist_val, df_expect)
+
+})
+
+test_that("unique_tidy() short examples", {
+
+  expect_equal(unique_tidy(c(1:3, NA), sort = "asc"), c(1:3))
+
+  expect_equal(unique_tidy(c(1:3, NA), sort = "desc"), c(3:1))
+
+  expect_equal(unique_tidy(c(3, 1, 2, NA), sort = "none"), c(3, 1, 2))
 
   expect_equal(
     factor(c(1:3, NA)) %>%
     as.factor() %>%
-    dist_values() %>%
+    unique_tidy() %>%
     class(), "character")
 
 })
 
+test_that("unique_tidy() works with comma separated vectors and lists", {
+
+  expect_equal(
+    c("1, 2, 3",
+      "2, 4, 5, 6",
+      "4, 1, 7") %>%
+      unique_tidy(., sep = ", "),
+    as.character(1:7)
+  )
+
+  expect_equal(
+    list(a = c(1:4), b = (4:6), c(5:10)) %>%
+      unique_tidy(),
+    c(1:10))
+
+})
+
+
+test_that("unique_tidy() example with factors", {
+
+  fctrs <- factor(letters[1:3], levels = c("b", "a", "c"))
+
+  expect_equal(unique_tidy(fctrs), c("b", "a", "c"))
+
+  expect_equal(unique_tidy(fctrs, sort = "none"), c("b", "a", "c"))
+
+  expect_equal(unique_tidy(fctrs, sort = "asc"), letters[1:3])
+
+  expect_equal(unique_tidy(fctrs, sort = "desc"), letters[3:1])
+
+
+
+})
+
+test_that("unique_tidy() `grp_data` argument works as expected", {
+
+  # warn character
+  expect_warning({
+    iris %>%
+      mutate(Species = as.character(Species)) %>%
+      group_by(Species) %>%
+      mutate(over(unique_tidy(Species),
+                   ~ if_else(Species == .x, 1, 0)))
+    })
+
+  # warn factor
+  expect_warning({
+    iris %>%
+      group_by(Species) %>%
+      mutate(over(unique_tidy(Species),
+                  ~ if_else(Species == .x, 1, 0)))
+  })
+
+  # silent
+  expect_warning({
+    iris %>%
+      group_by(Species) %>%
+      mutate(over(unique_tidy(Species, grp_data = "silent"),
+                  ~ if_else(Species == .x, 1, 0)))
+  }, NA)
+
+  # ungroup
+  expect_equal(
+    {iris %>%
+      mutate(Species = as.character(Species)) %>%
+      group_by(Species) %>%
+      transmute(over(unique_tidy(Species, grp_data = "ungroup"),
+                     ~ .x)) %>%
+      ncol()},
+    4L)
+})
+
+test_that("unique_tidy() supports tidy select in dplyr without dplyover", {
+  expect_equal({
+    mtcars %>%
+      mutate(values = list(unique_tidy(am:gear))) %>%
+      slice(1) %>%
+      pull(values) %>%
+      unlist},
+    c(0, 1, 3, 4, 5)
+    )
+})
+
+
+test_that("unique_tidy() `na.rm and `grp_data` arguments work as expected", {
+
+  expect_equal({
+    csat %>%
+      transmute(over(unique_tidy(email_rating,
+                                 na.rm = FALSE),
+                     ~ if_else(same_value(email_rating, .x), 1, 0))) %>%
+      ncol()
+  }, 6L)
+
+  expect_equal({
+    csat %>%
+      mutate(email_rating = as.character(email_rating)) %>%
+      transmute(over(unique_tidy(email_rating,
+                                 na.rm = FALSE),
+                     ~ if_else(same_value(email_rating, .x), 1, 0))) %>%
+      ncol()
+  }, 6L)
+
+  expect_equal({
+    csat %>%
+      group_by(email_rating) %>%
+      transmute(over(unique_tidy(email_rating,
+                                 grp_data = "ungroup",
+                                 na.rm = FALSE),
+                     ~ if_else(same_value(email_rating, .x), 1, 0))) %>%
+      ncol()
+    }, 7L)
+
+})
 
 test_that("use case: seq_rang() in over()", {
 
@@ -73,38 +204,6 @@ test_that("seq_rang() on dates", {
 
 })
 
-
-test_that("dist_values() works with comma separated vectors and lists", {
-
-  expect_equal(
-    c("1, 2, 3",
-      "2, 4, 5, 6",
-      "4, 1, 7") %>%
-      dist_values(., .sep = ", "),
-    as.character(1:7)
-  )
-
-  expect_equal(
-    list(a = c(1:4), b = (4:6), c(5:10)) %>%
-      dist_values(),
-    c(1:10))
-
-})
-
-
-test_that("dist_values() example with factors", {
-
-  fctrs <- factor(letters[1:3], levels = c("b", "a", "c"))
-
-  expect_equal(dist_values(fctrs), c("b", "a", "c"))
-
-  expect_equal(dist_values(fctrs, .sort = "asc"), letters[1:3])
-
-  expect_equal(dist_values(fctrs, .sort = "desc"), letters[3:1])
-
-  expect_equal(dist_values(fctrs, .sort = "none"), letters[1:3])
-
-})
 
 # more tests
 


### PR DESCRIPTION
New dplyr helper functions and `dist_values` was deprecated in favor of the new `unique_tidy`. Better name, can handle NA's, tidyselect, and can access the underyling full data to create columns inside dplyover calls.