### PR TITLE
Fix `inspect_call` to work with dev version of rlang::trace_back()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dplyover
 Title: Create columns by applying functions to vectors and/or columns in 'dplyr'
-Version: 0.0.8.9001
+Version: 0.0.8.9002
 Authors@R: 
     person(given = "Tim",
            family = "Tiefenbach",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dplyover 0.0.8.9002
+
+* fix `inspect_call` so that it work with dev version of rlang::trace_back()
+
 # dplyover 0.0.8.9001
 
 * hotfix which fixed a bug preventing {dplyover} to run on R versions <= 4.0

--- a/R/checks.R
+++ b/R/checks.R
@@ -57,5 +57,3 @@ data_mask_top <- function(env, recursive = FALSE, inherit = FALSE) {
 
   env
 }
-
-filter

--- a/R/show_affix.R
+++ b/R/show_affix.R
@@ -96,7 +96,7 @@ show_prefix <- function(.data = NULL, .xcols = NULL, .ycols = NULL) {
 #' @export
 show_suffix <- function(.data = NULL, .xcols = NULL, .ycols = NULL) {
 
-  if (is.null(.data) && !is.null(dplyover:::.last$value)) {
+  if (is.null(.data) && !is.null(.last$value)) {
 
     .data  <- .last$value$data
     .xcols <- .last$value$xcols

--- a/man/across2.Rd
+++ b/man/across2.Rd
@@ -108,10 +108,10 @@ transform the names, in the example setting them \code{tolower} by specifying th
 #> # A tibble: 150 x 4
 #>   sepal_product sepal_sum petal_product petal_sum
 #>           <dbl>     <dbl>         <dbl>     <dbl>
-#> 1          17.8       8.6         0.280      1.60
-#> 2          14.7       7.9         0.280      1.60
-#> 3          15.0       7.9         0.26       1.5 
-#> 4          14.3       7.7         0.3        1.7 
+#> 1          17.8       8.6          0.28       1.6
+#> 2          14.7       7.9          0.28       1.6
+#> 3          15.0       7.9          0.26       1.5
+#> 4          14.3       7.7          0.3        1.7
 #> # ... with 146 more rows
 }\if{html}{\out{</div>}}
 
@@ -132,12 +132,12 @@ by setting the \code{.comb} argument to \code{"minimal"}.\if{html}{\out{<div cla
                                      gsub("Petal", "P", .),
                      .comb = "minimal"))
 #> # A tibble: 3 x 7
-#>   Species    S.Length_S.Width S.Length_P.Length S.Length_P.Width S.Width_P.Length S.Width_P.Width
-#>   <fct>                 <dbl>             <dbl>            <dbl>            <dbl>           <dbl>
-#> 1 setosa                 0.74              0.27             0.28             0.18            0.23
-#> 2 versicolor             0.53              0.75             0.55             0.56            0.66
-#> 3 virginica              0.46              0.86             0.28             0.4             0.54
-#> # ... with 1 more variable: P.Length_P.Width <dbl>
+#>   Species    S.Length_S.Width S.Length_P.Length S.Length_P.Width S.Width_P.Length
+#>   <fct>                 <dbl>             <dbl>            <dbl>            <dbl>
+#> 1 setosa                 0.74              0.27             0.28             0.18
+#> 2 versicolor             0.53              0.75             0.55             0.56
+#> 3 virginica              0.46              0.86             0.28             0.4 
+#> # ... with 2 more variables: S.Width_P.Width <dbl>, P.Length_P.Width <dbl>
 }\if{html}{\out{</div>}}
 }
 

--- a/man/crossover.Rd
+++ b/man/crossover.Rd
@@ -138,16 +138,16 @@ as argument in \code{.fns} and specify the glue syntax in \code{.names}.\if{html
    glimpse
 #> Rows: 150
 #> Columns: 10
-#> $ Sepal.Length_lag1 <dbl> NA, 5.1, 4.9, 4.7, 4.6, 5.0, 5.4, 4.6, 5.0, 4.4, 4.9, 5.4, 4.8, 4.8, ~
-#> $ Sepal.Length_lag2 <dbl> NA, NA, 5.1, 4.9, 4.7, 4.6, 5.0, 5.4, 4.6, 5.0, 4.4, 4.9, 5.4, 4.8, 4~
-#> $ Sepal.Length_lag3 <dbl> NA, NA, NA, 5.1, 4.9, 4.7, 4.6, 5.0, 5.4, 4.6, 5.0, 4.4, 4.9, 5.4, 4.~
-#> $ Sepal.Length_lag4 <dbl> NA, NA, NA, NA, 5.1, 4.9, 4.7, 4.6, 5.0, 5.4, 4.6, 5.0, 4.4, 4.9, 5.4~
-#> $ Sepal.Length_lag5 <dbl> NA, NA, NA, NA, NA, 5.1, 4.9, 4.7, 4.6, 5.0, 5.4, 4.6, 5.0, 4.4, 4.9,~
-#> $ Sepal.Width_lag1  <dbl> NA, 3.5, 3.0, 3.2, 3.1, 3.6, 3.9, 3.4, 3.4, 2.9, 3.1, 3.7, 3.4, 3.0, ~
-#> $ Sepal.Width_lag2  <dbl> NA, NA, 3.5, 3.0, 3.2, 3.1, 3.6, 3.9, 3.4, 3.4, 2.9, 3.1, 3.7, 3.4, 3~
-#> $ Sepal.Width_lag3  <dbl> NA, NA, NA, 3.5, 3.0, 3.2, 3.1, 3.6, 3.9, 3.4, 3.4, 2.9, 3.1, 3.7, 3.~
-#> $ Sepal.Width_lag4  <dbl> NA, NA, NA, NA, 3.5, 3.0, 3.2, 3.1, 3.6, 3.9, 3.4, 3.4, 2.9, 3.1, 3.7~
-#> $ Sepal.Width_lag5  <dbl> NA, NA, NA, NA, NA, 3.5, 3.0, 3.2, 3.1, 3.6, 3.9, 3.4, 3.4, 2.9, 3.1,~
+#> $ Sepal.Length_lag1 <dbl> NA, 5.1, 4.9, 4.7, 4.6, 5.0, 5.4, 4.6, 5.0, 4.4, 4.9, 5.4~
+#> $ Sepal.Length_lag2 <dbl> NA, NA, 5.1, 4.9, 4.7, 4.6, 5.0, 5.4, 4.6, 5.0, 4.4, 4.9,~
+#> $ Sepal.Length_lag3 <dbl> NA, NA, NA, 5.1, 4.9, 4.7, 4.6, 5.0, 5.4, 4.6, 5.0, 4.4, ~
+#> $ Sepal.Length_lag4 <dbl> NA, NA, NA, NA, 5.1, 4.9, 4.7, 4.6, 5.0, 5.4, 4.6, 5.0, 4~
+#> $ Sepal.Length_lag5 <dbl> NA, NA, NA, NA, NA, 5.1, 4.9, 4.7, 4.6, 5.0, 5.4, 4.6, 5.~
+#> $ Sepal.Width_lag1  <dbl> NA, 3.5, 3.0, 3.2, 3.1, 3.6, 3.9, 3.4, 3.4, 2.9, 3.1, 3.7~
+#> $ Sepal.Width_lag2  <dbl> NA, NA, 3.5, 3.0, 3.2, 3.1, 3.6, 3.9, 3.4, 3.4, 2.9, 3.1,~
+#> $ Sepal.Width_lag3  <dbl> NA, NA, NA, 3.5, 3.0, 3.2, 3.1, 3.6, 3.9, 3.4, 3.4, 2.9, ~
+#> $ Sepal.Width_lag4  <dbl> NA, NA, NA, NA, 3.5, 3.0, 3.2, 3.1, 3.6, 3.9, 3.4, 3.4, 2~
+#> $ Sepal.Width_lag5  <dbl> NA, NA, NA, NA, NA, 3.5, 3.0, 3.2, 3.1, 3.6, 3.9, 3.4, 3.~
 }\if{html}{\out{</div>}}
 }
 
@@ -172,17 +172,17 @@ by replacing spaces with an underscore and setting all characters \code{tolower(
    glimpse
 #> Rows: 150
 #> Columns: 11
-#> $ type_new              <dbl> 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1,~
-#> $ type_existing         <dbl> 1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0,~
-#> $ type_reactivate       <dbl> 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,~
-#> $ product_basic         <dbl> 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 1,~
-#> $ product_advanced      <dbl> 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0,~
-#> $ product_premium       <dbl> 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0,~
-#> $ csat_very_unsatisfied <dbl> 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0,~
-#> $ csat_unsatisfied      <dbl> 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1,~
-#> $ csat_neutral          <dbl> 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,~
-#> $ csat_satisfied        <dbl> 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0,~
-#> $ csat_very_satisfied   <dbl> 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,~
+#> $ type_new              <dbl> 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0,~
+#> $ type_existing         <dbl> 1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1,~
+#> $ type_reactivate       <dbl> 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0,~
+#> $ product_basic         <dbl> 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1,~
+#> $ product_advanced      <dbl> 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0,~
+#> $ product_premium       <dbl> 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 0,~
+#> $ csat_very_unsatisfied <dbl> 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,~
+#> $ csat_unsatisfied      <dbl> 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0,~
+#> $ csat_neutral          <dbl> 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1,~
+#> $ csat_satisfied        <dbl> 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 0,~
+#> $ csat_very_satisfied   <dbl> 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,~
 }\if{html}{\out{</div>}}
 }
 }

--- a/man/over.Rd
+++ b/man/over.Rd
@@ -247,12 +247,12 @@ using a separator:\if{html}{\out{<div class="r">}}\preformatted{csat \%>\%
               .keep = "none") \%>\% glimpse
 #> Rows: 150
 #> Columns: 6
-#> $ rsp_friendly_staff <int> 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1,~
-#> $ rsp_good_service   <int> 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 1,~
-#> $ rsp_great_product  <int> 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1,~
-#> $ rsp_no_response    <int> 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0,~
-#> $ rsp_too_expensive  <int> 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0,~
-#> $ rsp_unfriendly     <int> 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0,~
+#> $ rsp_friendly_staff <int> 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0,~
+#> $ rsp_good_service   <int> 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0,~
+#> $ rsp_great_product  <int> 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0,~
+#> $ rsp_no_response    <int> 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1,~
+#> $ rsp_too_expensive  <int> 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0,~
+#> $ rsp_unfriendly     <int> 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1,~
 }\if{html}{\out{</div>}}
 }
 
@@ -278,10 +278,10 @@ Consider the following example of a purrr-style formula in \code{.fns} using \co
 #> # A tibble: 150 x 7
 #>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species Sepal Petal
 #>          <dbl>       <dbl>        <dbl>       <dbl> <fct>   <dbl> <dbl>
-#> 1          5.1         3.5          1.4         0.2 setosa    8.6  1.60
-#> 2          4.9         3            1.4         0.2 setosa    7.9  1.60
-#> 3          4.7         3.2          1.3         0.2 setosa    7.9  1.5 
-#> 4          4.6         3.1          1.5         0.2 setosa    7.7  1.7 
+#> 1          5.1         3.5          1.4         0.2 setosa    8.6   1.6
+#> 2          4.9         3            1.4         0.2 setosa    7.9   1.6
+#> 3          4.7         3.2          1.3         0.2 setosa    7.9   1.5
+#> 4          4.6         3.1          1.5         0.2 setosa    7.7   1.7
 #> # ... with 146 more rows
 }\if{html}{\out{</div>}}
 
@@ -293,10 +293,10 @@ The above syntax is equal to the more verbose:\if{html}{\out{<div class="r">}}\p
 #> # A tibble: 150 x 7
 #>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species Sepal Petal
 #>          <dbl>       <dbl>        <dbl>       <dbl> <fct>   <dbl> <dbl>
-#> 1          5.1         3.5          1.4         0.2 setosa    8.6  1.60
-#> 2          4.9         3            1.4         0.2 setosa    7.9  1.60
-#> 3          4.7         3.2          1.3         0.2 setosa    7.9  1.5 
-#> 4          4.6         3.1          1.5         0.2 setosa    7.7  1.7 
+#> 1          5.1         3.5          1.4         0.2 setosa    8.6   1.6
+#> 2          4.9         3            1.4         0.2 setosa    7.9   1.6
+#> 3          4.7         3.2          1.3         0.2 setosa    7.9   1.5
+#> 4          4.6         3.1          1.5         0.2 setosa    7.7   1.7
 #> # ... with 146 more rows
 }\if{html}{\out{</div>}}
 
@@ -319,10 +319,10 @@ A named list of functions:\if{html}{\out{<div class="r">}}\preformatted{iris \%>
 #> # A tibble: 150 x 4
 #>   Sepal_product Sepal_sum Petal_product Petal_sum
 #>           <dbl>     <dbl>         <dbl>     <dbl>
-#> 1          17.8       8.6         0.280      1.60
-#> 2          14.7       7.9         0.280      1.60
-#> 3          15.0       7.9         0.26       1.5 
-#> 4          14.3       7.7         0.3        1.7 
+#> 1          17.8       8.6          0.28       1.6
+#> 2          14.7       7.9          0.28       1.6
+#> 3          15.0       7.9          0.26       1.5
+#> 4          14.3       7.7          0.3        1.7
 #> # ... with 146 more rows
 }\if{html}{\out{</div>}}
 
@@ -335,10 +335,10 @@ Again, use the \code{.names} argument to control the output names:\if{html}{\out
 #> # A tibble: 150 x 4
 #>   product_Sepal sum_Sepal product_Petal sum_Petal
 #>           <dbl>     <dbl>         <dbl>     <dbl>
-#> 1          17.8       8.6         0.280      1.60
-#> 2          14.7       7.9         0.280      1.60
-#> 3          15.0       7.9         0.26       1.5 
-#> 4          14.3       7.7         0.3        1.7 
+#> 1          17.8       8.6          0.28       1.6
+#> 2          14.7       7.9          0.28       1.6
+#> 3          15.0       7.9          0.26       1.5
+#> 4          14.3       7.7          0.3        1.7
 #> # ... with 146 more rows
 }\if{html}{\out{</div>}}
 }

--- a/man/over2.Rd
+++ b/man/over2.Rd
@@ -117,15 +117,15 @@ each 'product' type:\if{html}{\out{<div class="r">}}\preformatted{csat \%>\%
   glimpse
 #> Rows: 150
 #> Columns: 9
-#> $ existing_advanced   <lgl> TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, FALSE, ~
-#> $ existing_premium    <lgl> FALSE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE~
-#> $ existing_basic      <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALS~
-#> $ reactivate_advanced <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE,~
-#> $ reactivate_premium  <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALS~
-#> $ reactivate_basic    <lgl> FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE~
-#> $ new_advanced        <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALS~
-#> $ new_premium         <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE~
-#> $ new_basic           <lgl> FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE, FALSE, FALSE, FALSE,~
+#> $ existing_advanced   <lgl> TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, TRUE, FALSE, FA~
+#> $ existing_premium    <lgl> FALSE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, ~
+#> $ existing_basic      <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,~
+#> $ reactivate_advanced <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, ~
+#> $ reactivate_premium  <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,~
+#> $ reactivate_basic    <lgl> FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, ~
+#> $ new_advanced        <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,~
+#> $ new_premium         <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,~
+#> $ new_basic           <lgl> FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE, FALSE, F~
 }\if{html}{\out{</div>}}
 }
 

--- a/man/select_vars.Rd
+++ b/man/select_vars.Rd
@@ -65,19 +65,21 @@ str_remove_all(names(iris), "Width")
 extract_names("Length|Width", .vars = names(iris))
 #> [1] "Length" "Width"
 str_extract(rep(names(iris), 2), "Length|Width")
-#>  [1] "Length" "Width"  "Length" "Width"  NA       "Length" "Width"  "Length" "Width"  NA
+#>  [1] "Length" "Width"  "Length" "Width"  NA       "Length" "Width"  "Length" "Width" 
+#> [10] NA
 }\if{html}{\out{</div>}}
 
 (2) \code{cut_names()} and \code{extract_names()} return only unique values:\if{html}{\out{<div class="r">}}\preformatted{cut_names("Width", .vars = rep(names(iris), 2))
 #> [1] "Sepal." "Petal."
 str_remove_all(rep(names(iris), 2), "Width")
-#>  [1] "Sepal.Length" "Sepal."       "Petal.Length" "Petal."       "Species"      "Sepal.Length"
-#>  [7] "Sepal."       "Petal.Length" "Petal."       "Species"
+#>  [1] "Sepal.Length" "Sepal."       "Petal.Length" "Petal."       "Species"     
+#>  [6] "Sepal.Length" "Sepal."       "Petal.Length" "Petal."       "Species"
 
 extract_names("Length|Width", .vars = names(iris))
 #> [1] "Length" "Width"
 str_extract(rep(names(iris), 2), "Length|Width")
-#>  [1] "Length" "Width"  "Length" "Width"  NA       "Length" "Width"  "Length" "Width"  NA
+#>  [1] "Length" "Width"  "Length" "Width"  NA       "Length" "Width"  "Length" "Width" 
+#> [10] NA
 }\if{html}{\out{</div>}}
 
 The examples above do not show that \code{cut_names()} removes \emph{all} strings matching
@@ -99,26 +101,26 @@ mutate(over(cut_names(".Width"),
             ~ .("\{.x\}.Width") * .("\{.x\}.Length"),
             .names = "Product_\{x\}"))
 #> # A tibble: 150 x 7
-#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species Product_Sepal Product_Petal
-#>          <dbl>       <dbl>        <dbl>       <dbl> <fct>           <dbl>         <dbl>
-#> 1          5.1         3.5          1.4         0.2 setosa           17.8         0.280
-#> 2          4.9         3            1.4         0.2 setosa           14.7         0.280
-#> 3          4.7         3.2          1.3         0.2 setosa           15.0         0.26 
-#> 4          4.6         3.1          1.5         0.2 setosa           14.3         0.3  
-#> # ... with 146 more rows
+#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species Product_Sepal
+#>          <dbl>       <dbl>        <dbl>       <dbl> <fct>           <dbl>
+#> 1          5.1         3.5          1.4         0.2 setosa           17.8
+#> 2          4.9         3            1.4         0.2 setosa           14.7
+#> 3          4.7         3.2          1.3         0.2 setosa           15.0
+#> 4          4.6         3.1          1.5         0.2 setosa           14.3
+#> # ... with 146 more rows, and 1 more variable: Product_Petal <dbl>
 
 iris \%>\%
   mutate(over(extract_names("Length|Width"),
               ~.("Petal.\{.x\}") * .("Sepal.\{.x\}"),
              .names = "Product_\{x\}"))
 #> # A tibble: 150 x 7
-#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species Product_Length Product_Width
-#>          <dbl>       <dbl>        <dbl>       <dbl> <fct>            <dbl>         <dbl>
-#> 1          5.1         3.5          1.4         0.2 setosa            7.14          0.7 
-#> 2          4.9         3            1.4         0.2 setosa            6.86          0.6 
-#> 3          4.7         3.2          1.3         0.2 setosa            6.11          0.64
-#> 4          4.6         3.1          1.5         0.2 setosa            6.9           0.62
-#> # ... with 146 more rows
+#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species Product_Length
+#>          <dbl>       <dbl>        <dbl>       <dbl> <fct>            <dbl>
+#> 1          5.1         3.5          1.4         0.2 setosa            7.14
+#> 2          4.9         3            1.4         0.2 setosa            6.86
+#> 3          4.7         3.2          1.3         0.2 setosa            6.11
+#> 4          4.6         3.1          1.5         0.2 setosa            6.9 
+#> # ... with 146 more rows, and 1 more variable: Product_Width <dbl>
 }\if{html}{\out{</div>}}
 
 What problem does \code{cut_names()} solve?

--- a/man/show_affix.Rd
+++ b/man/show_affix.Rd
@@ -56,11 +56,11 @@ any arguments:\if{html}{\out{<div class="r">}}\preformatted{ iris \%>\%
                               sum = ~ .x + .y),
                   .names = "\{pre\}_\{fn\}"))
 #> Error: Problem with `mutate()` input `..1`.
+#> i `..1 = across2(...)`.
 #> x Problem with `across2()` input `.names`.
 #> i When `\{pre\}` is used inside `.names` each pair of input variables in `.xcols` and `.ycols` must share a common prefix of length > 0.
 #> x For at least one pair of variables a shared prefix could not be extracted.
 #> i Run `show_prefix()` to see the prefixes for each variable pair.
-#> i Input `..1` is `across2(...)`.
 show_prefix()
 #> # A tibble: 2 x 3
 #>   .xcols       .ycols      prefix

--- a/man/string_eval.Rd
+++ b/man/string_eval.Rd
@@ -36,10 +36,10 @@ well as 'Petal.Width' and 'Petal.Length'.\if{html}{\out{<div class="r">}}\prefor
 #> # A tibble: 150 x 7
 #>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species Sepal Petal
 #>          <dbl>       <dbl>        <dbl>       <dbl> <fct>   <dbl> <dbl>
-#> 1          5.1         3.5          1.4         0.2 setosa    8.6  1.60
-#> 2          4.9         3            1.4         0.2 setosa    7.9  1.60
-#> 3          4.7         3.2          1.3         0.2 setosa    7.9  1.5 
-#> 4          4.6         3.1          1.5         0.2 setosa    7.7  1.7 
+#> 1          5.1         3.5          1.4         0.2 setosa    8.6   1.6
+#> 2          4.9         3            1.4         0.2 setosa    7.9   1.6
+#> 3          4.7         3.2          1.3         0.2 setosa    7.9   1.5
+#> 4          4.6         3.1          1.5         0.2 setosa    7.7   1.7
 #> # ... with 146 more rows
 }\if{html}{\out{</div>}}
 
@@ -51,10 +51,10 @@ The above syntax is equal to the more verbose:\if{html}{\out{<div class="r">}}\p
 #> # A tibble: 150 x 7
 #>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species Sepal Petal
 #>          <dbl>       <dbl>        <dbl>       <dbl> <fct>   <dbl> <dbl>
-#> 1          5.1         3.5          1.4         0.2 setosa    8.6  1.60
-#> 2          4.9         3            1.4         0.2 setosa    7.9  1.60
-#> 3          4.7         3.2          1.3         0.2 setosa    7.9  1.5 
-#> 4          4.6         3.1          1.5         0.2 setosa    7.7  1.7 
+#> 1          5.1         3.5          1.4         0.2 setosa    8.6   1.6
+#> 2          4.9         3            1.4         0.2 setosa    7.9   1.6
+#> 3          4.7         3.2          1.3         0.2 setosa    7.9   1.5
+#> 4          4.6         3.1          1.5         0.2 setosa    7.7   1.7
 #> # ... with 146 more rows
 }\if{html}{\out{</div>}}
 
@@ -75,10 +75,10 @@ quotation marks \code{.("{cur_column()}.Width")}.\if{html}{\out{<div class="r">}
 #> # A tibble: 150 x 7
 #>   Sepal Sepal.Width Petal Petal.Width Species Sepal_sum Petal_sum
 #>   <dbl>       <dbl> <dbl>       <dbl> <fct>       <dbl>     <dbl>
-#> 1   5.1         3.5   1.4         0.2 setosa        8.6      1.60
-#> 2   4.9         3     1.4         0.2 setosa        7.9      1.60
-#> 3   4.7         3.2   1.3         0.2 setosa        7.9      1.5 
-#> 4   4.6         3.1   1.5         0.2 setosa        7.7      1.7 
+#> 1   5.1         3.5   1.4         0.2 setosa        8.6       1.6
+#> 2   4.9         3     1.4         0.2 setosa        7.9       1.6
+#> 3   4.7         3.2   1.3         0.2 setosa        7.9       1.5
+#> 4   4.6         3.1   1.5         0.2 setosa        7.7       1.7
 #> # ... with 146 more rows
 }\if{html}{\out{</div>}}
 
@@ -90,10 +90,10 @@ A similar approach can be achieved using \code{purrr::map} in combination with \
 #> # A tibble: 150 x 7
 #>   Sepal Sepal.Width Petal Petal.Width Species Sepal_sum Petal_sum
 #>   <dbl>       <dbl> <dbl>       <dbl> <fct>       <dbl>     <dbl>
-#> 1   5.1         3.5   1.4         0.2 setosa        8.6      1.60
-#> 2   4.9         3     1.4         0.2 setosa        7.9      1.60
-#> 3   4.7         3.2   1.3         0.2 setosa        7.9      1.5 
-#> 4   4.6         3.1   1.5         0.2 setosa        7.7      1.7 
+#> 1   5.1         3.5   1.4         0.2 setosa        8.6       1.6
+#> 2   4.9         3     1.4         0.2 setosa        7.9       1.6
+#> 3   4.7         3.2   1.3         0.2 setosa        7.9       1.5
+#> 4   4.6         3.1   1.5         0.2 setosa        7.7       1.7
 #> # ... with 146 more rows
 }\if{html}{\out{</div>}}
 }

--- a/vignettes/performance.Rmd
+++ b/vignettes/performance.Rmd
@@ -92,8 +92,8 @@ control which columns are retained in the output. This works well with genuine
 {dplyr} functions like `across`:
 
 ```{r}
-diamonds %>% mutate(across(z, ~ .x + y),
-                    .keep = "used")
+# diamonds %>% mutate(across(z, ~ .x + y),
+#                     .keep = "used")
 ```
 `.keep` not only recognizes that `across` is *used* on colum 'z', it also
 registers that we *used* column 'y' in `across`'s `.fns` argument.
@@ -123,8 +123,8 @@ Example:<br>
 We can do this with `dplyr::across`:
 ```{r}
 prefix <- "lag1"
-tibble(a = 1:25) %>%
-  mutate(across(everything(), lag, 1, .names = "{.col}_{prefix}"))
+# tibble(a = 1:25) %>%
+#   mutate(across(everything(), lag, 1, .names = "{.col}_{prefix}"))
 ```
 
 In {dplyover} we would need to construct the names outside of the function call

--- a/vignettes/performance.Rmd
+++ b/vignettes/performance.Rmd
@@ -387,13 +387,15 @@ lagged_vars <- bench::mark(iterations = 50L, check = FALSE,
                        list(lag = ~ lag(.x, .y)),
                        .names = "{xcol}_{fn}{y}"))
   },
-  # across_map_dfc = {
-  #   diamonds %>%
-  #     mutate(across(c(x,y,z),
-  #                   ~ map_dfc(set_names(1:5, paste0("lag", 1:5)),
-  #                             function(y) lag(.x, y)))) %>%
-  #   do.call(data.frame, .)
-  # },
+  across_map_dfc = {
+    diamonds %>%
+      mutate(across(c(x,y,z),
+                    function(x) {
+                      map_dfc(set_names(1:5, paste0("lag", 1:5)),
+                              function(y) lag(x, y))})
+             ) %>%
+    do.call(data.frame, .)
+  },
 
   reduce_cst_fct = {
     diamonds %>%

--- a/vignettes/performance.Rmd
+++ b/vignettes/performance.Rmd
@@ -92,8 +92,8 @@ control which columns are retained in the output. This works well with genuine
 {dplyr} functions like `across`:
 
 ```{r}
-# diamonds %>% mutate(across(z, ~ .x + y),
-#                     .keep = "used")
+diamonds %>% mutate(across(z, ~ .x + y),
+                    .keep = "used")
 ```
 `.keep` not only recognizes that `across` is *used* on colum 'z', it also
 registers that we *used* column 'y' in `across`'s `.fns` argument.
@@ -123,8 +123,8 @@ Example:<br>
 We can do this with `dplyr::across`:
 ```{r}
 prefix <- "lag1"
-# tibble(a = 1:25) %>%
-#   mutate(across(everything(), lag, 1, .names = "{.col}_{prefix}"))
+tibble(a = 1:25) %>%
+  mutate(across(everything(), lag, 1, .names = "{.col}_{prefix}"))
 ```
 
 In {dplyover} we would need to construct the names outside of the function call

--- a/vignettes/performance.Rmd
+++ b/vignettes/performance.Rmd
@@ -350,11 +350,11 @@ diamonds %>%
                     .names = "{xcol}_{fn}{y}"))
 
 # across and map_dfc
-diamonds %>% 
+diamonds %>%
   mutate(across(c(x,y,z),
                 ~ map_dfc(set_names(1:5, paste0("lag", 1:5)),
                           function(y) lag(.x, y))
-                )) %>% 
+                )) %>%
   do.call(data.frame, .)
 
 # custom function with reduce
@@ -387,13 +387,13 @@ lagged_vars <- bench::mark(iterations = 50L, check = FALSE,
                        list(lag = ~ lag(.x, .y)),
                        .names = "{xcol}_{fn}{y}"))
   },
-  across_map_dfc = {
-    diamonds %>%
-      mutate(across(c(x,y,z),
-                    ~ map_dfc(set_names(1:5, paste0("lag", 1:5)),
-                              function(y) lag(.x, y)))) %>%
-    do.call(data.frame, .)
-  },
+  # across_map_dfc = {
+  #   diamonds %>%
+  #     mutate(across(c(x,y,z),
+  #                   ~ map_dfc(set_names(1:5, paste0("lag", 1:5)),
+  #                             function(y) lag(.x, y)))) %>%
+  #   do.call(data.frame, .)
+  # },
 
   reduce_cst_fct = {
     diamonds %>%


### PR DESCRIPTION
This pull request fixes `inspect_call` so that it works with prior verisons of  `rlang::trace_back()` as well as with the latest dev version 0.4.11.9001. This closes #18.